### PR TITLE
Update to Stylus syntax

### DIFF
--- a/Stylus.sublime-settings
+++ b/Stylus.sublime-settings
@@ -5,7 +5,7 @@
     // The default Stylus syntax
     "hayaku_CSS_syntax_autoguess": [
         "    selector             ",
-        "      property: value    "
+        "      property value    "
     ],
 
     "auto_complete": false,


### PR DESCRIPTION
I've updated the stylus syntax settings file to remove the semicolons in the hayaku_CSS_syntax_autoguess config.
