### PR TITLE
None value for border* properties

### DIFF
--- a/dictionaries/hayaku_CSS_dictionary.json
+++ b/dictionaries/hayaku_CSS_dictionary.json
@@ -203,7 +203,7 @@
         "always_positive": true
     },{
         "name": [ "border", "border-top", "border-right", "border-bottom", "border-left" ],
-        "values": [ "<border-color>", "<_border-style>", "<border-width>" ],
+        "values": [ "none", "<border-color>", "<_border-style>", "<border-width>" ],
         "default": "1px solid"
     },{
         "name": [ "border-radius", "border-top-right-radius", "border-top-left-radius", "border-bottom-left-radius", "border-bottom-right-radius" ],


### PR DESCRIPTION
It’s should be possible to disable border\* shortcut properties with none keyword.
