### PR TITLE
Add css inside js support

### DIFF
--- a/hayaku_sublime_contexts.py
+++ b/hayaku_sublime_contexts.py
@@ -26,7 +26,7 @@ class HayakuAtCssContext(sublime_plugin.EventListener):
             return None
 
         # Looking for the scope
-        if not view.score_selector(view.sel()[0].begin(),'source.css, source.stylus, source.sass, source.scss, source.less, source.postcss'):
+        if not view.score_selector(view.sel()[0].begin(),'source.css, source.stylus, source.sass, source.scss, source.less, source.postcss, source.css.embedded.js'):
             return None
 
         return True
@@ -94,7 +94,7 @@ class HayakuStyleContext(sublime_plugin.EventListener):
 
         # Looking for the scope
         # TODO: Make it expandable in HTML's attributes (+ left/right fixes)
-        if view.score_selector(region.begin(),'source.css -meta.selector.css, source.stylus, source.sass, source.scss, source.less, source.postcss') == 0:
+        if view.score_selector(region.begin(),'source.css -meta.selector.css, source.stylus, source.sass, source.scss, source.less, source.postcss, source.css.embedded.js') == 0:
             return None
 
         # Determining the left and the right parts


### PR DESCRIPTION
Sometimes css included inside js files (for example, via https://emotion.sh libs or similar) and sublime already detects the syntax correctly (for example, via `Naomi` lib) with `source.css.embedded.js` scope. This PR adds support such embedded css to Hayku.